### PR TITLE
Updated terraform modules and launch-client.sh script. Updated autopi…

### DIFF
--- a/gke-stateful-postgres/helm/postgresql-bootstrap/values.yaml
+++ b/gke-stateful-postgres/helm/postgresql-bootstrap/values.yaml
@@ -12,7 +12,7 @@ postgresql-ha:
   postgresql:
     image:
       repository: bitnami/postgresql-repmgr
-      tag: 14.5.0-debian-11-r9
+      tag: 14.5.0-debian-11-r6
     replicaCount: 3
     nodeAffinityPreset:
       type: "soft"
@@ -39,7 +39,7 @@ postgresql-ha:
   pgpool:
     image:
       repository: bitnami/pgpool
-      tag: 4.3.3-debian-11-r6
+      tag: 4.3.3-debian-11-r1
     replicaCount: 1
     tolerations:
     - key: "app.stateful/component"
@@ -57,7 +57,7 @@ postgresql-ha:
     enabled: true
     image:
       repository: bitnami/postgres-exporter
-      tag: 0.11.0-debian-11-r1
+      tag: 0.11.1-debian-11-r0
 
 gkeBackup: # Enable this for Standard GKE, ignore during Autopilot test
   enabled: true

--- a/gke-stateful-postgres/scripts/launch-client.sh
+++ b/gke-stateful-postgres/scripts/launch-client.sh
@@ -2,11 +2,13 @@
 
 # Launch Pod as DB Client, setup DB password as environment variable to avoid the prompt
 # Usage, run this script from the postgresql directory
-# scripts/launch-client.sh [pod-name]
+# scripts/launch-client.sh
+
+POD_CLIENT=pg-client
+NAMESPACE=postgresql
 
 launch_pod () {
   echo "Launching Pod $POD_CLIENT in the namespace $NAMESPACE ..."
-  export NAMESPACE=postgresql
   export POSTGRES_PASSWORD=$(kubectl get secret --namespace $NAMESPACE postgresql-postgresql-ha-postgresql -o jsonpath="{.data.postgresql-password}" | base64 -d)
   export REPMGR_PASSWORD=$(kubectl get secret --namespace $NAMESPACE postgresql-postgresql-ha-postgresql -o jsonpath="{.data.repmgr-password}" | base64 -d)
   export IMAGE="us-docker.pkg.dev/$PROJECT_ID/main/bitnami/postgresql-repmgr:14.5.0-debian-11-r9"
@@ -38,16 +40,9 @@ check_status () {
   echo "Pod: $POD_CLIENT is $POD_STATUS"
 }
 
-# Starts here
-if [[ "$1" == "" ]]; then
-  POD_CLIENT=postgresql-client1
-else
-  POD_CLIENT=$1
-fi
-
 echo ""
 if [[ "$PROJECT_ID" == "" ]]; then
-  echo "Variable Project_ID is missing"
+  echo "Variable 'PROJECT_ID' is unset"
 else 
   launch_pod
   check_status

--- a/gke-stateful-postgres/terraform/gke-autopilot/main.tf
+++ b/gke-stateful-postgres/terraform/gke-autopilot/main.tf
@@ -1,5 +1,13 @@
 # google_client_config and kubernetes provider must be explicitly specified like the following.
 data "google_client_config" "default" {}
+// [START artifact_reg_setup]
+resource "google_artifact_registry_repository" "main" {
+  location      = "us"
+  repository_id = "main"
+  format        = "DOCKER"
+  project       = var.project_id
+}
+// [END artifact_reg_setup]
 
 module "network" {
   source     = "../modules/network"
@@ -19,13 +27,12 @@ module "gke-db1-autopilot" {
   ip_range_pods              = "ip-range-pods-db1"
   ip_range_services          = "ip-range-svc-db1"
   horizontal_pod_autoscaling = true
-  # release_channel                 = "REGULAR" # Default version is 1.22 in REGULAR so commented it out to specify V1.24 via var.kubernetes_version
+  release_channel                 = "RAPID" # Default version is 1.22 in REGULAR. GMP on Autopilot requires V1.25 via var.kubernetes_version
   enable_vertical_pod_autoscaling = true
   enable_private_endpoint         = false
   enable_private_nodes            = true
   master_ipv4_cidr_block          = "172.16.0.0/28"
   create_service_account          = false
-  monitoring_enable_managed_prometheus = true
 }
 
 module "gke-db2-autopilot" {
@@ -41,11 +48,10 @@ module "gke-db2-autopilot" {
   ip_range_pods              = "ip-range-pods-db2"
   ip_range_services          = "ip-range-svc-db2"
   horizontal_pod_autoscaling = true
-  # release_channel                 = "REGULAR" # Default version is 1.22 in REGULAR so commented it out to specify V1.24 via var.kubernetes_version
+  release_channel                 = "RAPID" # Default version is 1.22 in REGULAR. GMP on Autopilot requires V1.25 via var.kubernetes_version
   enable_vertical_pod_autoscaling = true
   enable_private_endpoint         = false
   enable_private_nodes            = true
   master_ipv4_cidr_block          = "172.16.0.16/28"
   create_service_account          = false
-  monitoring_enable_managed_prometheus = true
 }

--- a/gke-stateful-postgres/terraform/modules/beta-autopilot-private-cluster/README.md
+++ b/gke-stateful-postgres/terraform/modules/beta-autopilot-private-cluster/README.md
@@ -1,6 +1,7 @@
 # Terraform Kubernetes Engine Module
 
 This Module is a fork from Google's upstream `beta-autopilot-private-cluster` Module at
-https://github.com/terraform-google-modules/terraform-google-kubernetes-engine.
+https://github.com/terraform-google-modules/terraform-google-kubernetes-engine, version
+`v24.0.0`.
 
 It contains an additional `override.tf` to enable Backup for GKE

--- a/gke-stateful-postgres/terraform/modules/beta-autopilot-private-cluster/override.tf
+++ b/gke-stateful-postgres/terraform/modules/beta-autopilot-private-cluster/override.tf
@@ -1,4 +1,6 @@
 resource "google_container_cluster" "primary" {
+  # Set min_master_version explicitly, due to https://github.com/terraform-google-modules/terraform-google-kubernetes-engine/issues/1356
+  min_master_version = var.kubernetes_version != "latest" ? var.kubernetes_version : null
   addons_config {
     gke_backup_agent_config {
       enabled = true

--- a/gke-stateful-postgres/terraform/modules/beta-autopilot-private-cluster/versions.tf
+++ b/gke-stateful-postgres/terraform/modules/beta-autopilot-private-cluster/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.36.0, < 5.0"
+      version = ">= 4.42.0, < 5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -29,6 +29,6 @@ terraform {
     }
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:beta-autopilot-private-cluster/v23.3.0"
+    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:beta-autopilot-private-cluster/v24.0.0"
   }
 }

--- a/gke-stateful-postgres/terraform/modules/beta-private-cluster/README.md
+++ b/gke-stateful-postgres/terraform/modules/beta-private-cluster/README.md
@@ -1,4 +1,5 @@
 # Terraform Kubernetes Engine Module
 
 This Module is a fork from Google's upstream `beta-private-cluster` Module at
-https://github.com/terraform-google-modules/terraform-google-kubernetes-engine.
+https://github.com/terraform-google-modules/terraform-google-kubernetes-engine, version
+`v24.0.0`.

--- a/gke-stateful-postgres/terraform/modules/beta-private-cluster/cluster.tf
+++ b/gke-stateful-postgres/terraform/modules/beta-private-cluster/cluster.tf
@@ -430,7 +430,6 @@ resource "google_container_cluster" "primary" {
 resource "google_container_node_pool" "pools" {
   provider = google-beta
   for_each = local.node_pools
-
   name     = each.key
   project  = var.project_id
   location = local.location
@@ -637,7 +636,6 @@ resource "google_container_node_pool" "pools" {
 resource "google_container_node_pool" "windows_pools" {
   provider = google-beta
   for_each = local.windows_node_pools
-
   name     = each.key
   project  = var.project_id
   location = local.location

--- a/gke-stateful-postgres/terraform/modules/beta-private-cluster/versions.tf
+++ b/gke-stateful-postgres/terraform/modules/beta-private-cluster/versions.tf
@@ -21,7 +21,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 4.36.0, < 5.0"
+      version = ">= 4.42.0, < 5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
@@ -29,6 +29,6 @@ terraform {
     }
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:beta-private-cluster/v23.3.0"
+    module_name = "blueprints/terraform/terraform-google-kubernetes-engine:beta-private-cluster/v24.0.0"
   }
 }


### PR DESCRIPTION
 * Update terraform modules to v24.0
 * Update launch-client.sh to name one pod
 * Update autopilot to respect kubernetes_version, when specifying release channel. This allows using 1.25 on Autopilot.