### PR TITLE
Add toleration/nodeSelector/affinity to allow prepareforha template to deploy to the correct nodepool

### DIFF
--- a/gke-stateful-postgres/helm/postgresql-bootstrap/templates/prepareforha.yaml
+++ b/gke-stateful-postgres/helm/postgresql-bootstrap/templates/prepareforha.yaml
@@ -24,6 +24,22 @@ spec:
                 values:
                 - prepare-three-zone-ha
             topologyKey: "topology.kubernetes.io/zone"
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: cloud.google.com/compute-class
+                operator: In
+                values:
+                - "Scale-Out"
+            weight: 1
+      nodeSelector:
+        app.stateful/component: postgresql
+      tolerations:
+      - effect: NoSchedule
+        key: app.stateful/component
+        operator: Equal
+        value: postgresql
       containers:
       - name: prepare-three-zone-ha
         image: busybox:latest


### PR DESCRIPTION
Add toleration/nodeSelector/affinity to allow prepareforha template to deploy to the correct nodepool